### PR TITLE
Update MQTTAsync.c - memory leak on MQTTAsync_addCommand

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -1168,6 +1168,28 @@ static int MQTTAsync_restoreCommands(MQTTAsyncs* client)
 }
 #endif
 
+/**
+ * List callback function for comparing client handles and command types being CONNECT or DISCONNECT 
+ * @param a first MQTTAsync_queuedCommand pointer
+ * @param b second MQTTAsync_queuedCommand pointer
+ * @return boolean indicating whether a and b are equal
+ */
+static int clientCompareConnectCommand(void* a, void* b)
+{
+	MQTTAsync_queuedCommand* cmd1 = (MQTTAsync_queuedCommand*)a;
+	MQTTAsync_queuedCommand* cmd2 = (MQTTAsync_queuedCommand*)b;
+	if (cmd1->client == cmd2->client)
+	{
+		if (cmd1->command.type == cmd2->command.type)
+		{
+			if (cmd1->command.type == CONNECT || cmd1->command.type == DISCONNECT)
+			{
+				return 1; //Item found in the list
+			}
+		}
+	}
+	return 0;	//Item NOT found in the list
+}
 
 static int MQTTAsync_addCommand(MQTTAsync_queuedCommand* command, int command_size)
 {
@@ -1189,7 +1211,10 @@ static int MQTTAsync_addCommand(MQTTAsync_queuedCommand* command, int command_si
 		if (head != NULL && head->client == command->client && head->command.type == command->command.type)
 			MQTTAsync_freeCommand(command); /* ignore duplicate connect or disconnect command */
 		else
+		{ 
+			ListRemoveItem(commands, command, clientCompareConnectCommand); /* remove command from the list if already there */
 			ListInsert(commands, command, command_size, commands->first); /* add to the head of the list */
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Added clientCompareConnectCommand callback function.
In MQTTAsync_addCommand check if a connect or disconnect command for a specific client is already in the list. If present, then remove it and insert the new one


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


